### PR TITLE
Show /recalculate statistics by category

### DIFF
--- a/bot/core/handlers/recalculate.py
+++ b/bot/core/handlers/recalculate.py
@@ -12,20 +12,20 @@ async def recalculate_chat(message: types.Message, bot: Bot):
     chat_id = message.chat.id
     tool_box = MessageService(bot)
     await tool_box.cleaner.delete_user_message(message)
-    expenses = await ReportService.get_expenses_by_chat(chat_id)
+    category_summary = await ReportService.get_category_summary(chat_id)
 
-    if not expenses:
+    if not category_summary:
         await message.answer("⚠️ В этом чате пока нет записанных расходов.")
         return
 
     total = await ReportService.get_total_by_chat(chat_id)
 
     lines = [
-        f"{e.category.name if e.category else 'Без категории'} - {e.amount:.2f} ₽ ({ReportService.format_date(e)})"
-        for e in expenses[:20]
+        f"{idx}. {category} — {amount:.2f} ₽"
+        for idx, (category, amount) in enumerate(category_summary, start=1)
     ]
 
-    text = "📊 Уже записанные расходы:\n\n"
+    text = "📊 Расходы по категориям:\n\n"
     text += "\n".join(lines)
     text += f"\n\nВсего: {total:.2f} ₽"
 

--- a/project/apps/expenses/services/report_service.py
+++ b/project/apps/expenses/services/report_service.py
@@ -43,4 +43,7 @@ class ReportService:
             .annotate(total=Sum("amount"))
             .order_by("-total")
         )
-        return {row["category__name"] or "Без категории": float(row["total"]) for row in qs}
+        return [
+            (row["category__name"] or "Без категории", float(row["total"]))
+            for row in qs
+        ]


### PR DESCRIPTION
## Summary
- update the /recalculate handler to output spending grouped by category with totals
- return an ordered list of category totals from the report service for easier formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de721428648326bb7ff1c68f9a92b8