### PR TITLE
Normalize expense amount handling

### DIFF
--- a/project/apps/expenses/services/expense_parser.py
+++ b/project/apps/expenses/services/expense_parser.py
@@ -82,8 +82,13 @@ class ExpenseParser:
             if amount is None:
                 i += 1
                 continue
+
+            # Мы учитываем траты, поэтому знак перед суммой
+            # не должен влиять на величину расхода. Если пользователь
+            # поставил «-» перед числом, воспринимаем это как то же
+            # самое значение, что и без знака.
             if sign == "-":
-                amount = -amount
+                amount = abs(amount)
 
             category = cls._strip_match_from_line(line, m)
 

--- a/project/apps/expenses/services/expense_service.py
+++ b/project/apps/expenses/services/expense_service.py
@@ -16,9 +16,11 @@ class ExpenseService:
         for amount, category_name in items:
             category = await CategoryService.get_or_create(category_name)
 
+            normalized_amount = abs(amount)
+
             expense = await Expense.objects.acreate(
                 user=user,
-                amount=amount,
+                amount=normalized_amount,
                 category=category,
                 chat_id=message.chat.id,
                 add_attr={

--- a/project/apps/expenses/services/report_service.py
+++ b/project/apps/expenses/services/report_service.py
@@ -1,6 +1,7 @@
 from asgiref.sync import sync_to_async
 from project.apps.expenses.models import Expense
 from django.db.models import Q, Sum
+from django.db.models.functions import Abs
 from datetime import datetime
 
 
@@ -32,7 +33,7 @@ class ReportService:
         filter_condition = Q(chat_id=chat_id) | Q(add_attr__chat_id=chat_id)
         result = (
             Expense.objects.filter(filter_condition)
-            .aggregate(total=Sum("amount"))
+            .aggregate(total=Sum(Abs("amount")))
         )
         return float(result["total"] or 0)
 
@@ -43,7 +44,7 @@ class ReportService:
         qs = (
             Expense.objects.filter(filter_condition)
             .values("category__name")
-            .annotate(total=Sum("amount"))
+            .annotate(total=Sum(Abs("amount")))
             .order_by("-total")
         )
         return [


### PR DESCRIPTION
## Summary
- ignore negative signs when parsing expenses so inputs with and without `-` are treated the same
- store expenses using absolute values before saving to the database
- calculate totals and category summaries using absolute amounts to include previously negative records

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de85cd7dac8326a0d9395a60e9ada5