### PR TITLE
Add period-aware reporting and command parsing

### DIFF
--- a/bot/core/handlers/recalculate.py
+++ b/bot/core/handlers/recalculate.py
@@ -1,6 +1,7 @@
 from aiogram import Router, types, Bot
 from aiogram.filters import Command
 
+from bot.services import CommandService
 from bot.services.message_service import MessageService
 from project.apps.expenses.services.report_service import ReportService
 
@@ -11,20 +12,30 @@ admin_router = Router()
 async def recalculate_chat(message: types.Message, bot: Bot):
     chat_id = message.chat.id
     tool_box = MessageService(bot)
+    period = CommandService.parse_period(message.text or "")
     await tool_box.cleaner.delete_user_message(message)
-    category_summary = await ReportService.get_category_summary(chat_id)
+    category_summary = await ReportService.get_category_summary(
+        chat_id,
+        start=period.start,
+        end=period.end,
+    )
 
     if not category_summary:
         await message.answer("⚠️ В этом чате пока нет записанных расходов.")
         return
 
-    total = await ReportService.get_total_by_chat(chat_id)
+    total = await ReportService.get_total_by_chat(
+        chat_id,
+        start=period.start,
+        end=period.end,
+    )
 
     lines = [
         f"{idx}. {category} — {amount:.2f} ₽"
         for idx, (category, amount) in enumerate(category_summary, start=1)
     ]
-    text = "📊 Расходы по категориям:\n\n"
+    suffix = f" {period.label}" if period.label else ""
+    text = f"📊 Расходы по категориям{suffix}:\n\n"
     text += "\n".join(lines)
     text += f"\n\nВсего: {total:.2f} ₽"
     await message.answer(text)

--- a/bot/services/__init__.py
+++ b/bot/services/__init__.py
@@ -1,0 +1,1 @@
+from .command_service import CommandService  # noqa: F401

--- a/bot/services/command_service.py
+++ b/bot/services/command_service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from typing import Optional
+
+from django.utils import timezone
+
+from project.apps.expenses.services.periods import PeriodRange
+
+
+class CommandService:
+    """Utilities to help parsing bot commands."""
+
+    _DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+    @classmethod
+    def parse_period(cls, text: str, now: Optional[datetime] = None) -> PeriodRange:
+        """Extract a period range from command text."""
+
+        query = cls._extract_query(text)
+        if not query:
+            return PeriodRange()
+
+        normalized = " ".join(query.lower().split())
+        normalized = normalized.replace("за ", "").strip()
+
+        now = (now or timezone.now()).astimezone(timezone.get_current_timezone())
+
+        if not normalized or normalized in {"all", "всё", "все", "за всё время", "все время"}:
+            return PeriodRange()
+
+        if any(key in normalized for key in ("today", "сегодня")):
+            start = cls._start_of_day(now)
+            return PeriodRange(start=start, end=start + timedelta(days=1), label="за сегодня")
+
+        if any(key in normalized for key in ("yesterday", "вчера")):
+            start = cls._start_of_day(now - timedelta(days=1))
+            return PeriodRange(start=start, end=start + timedelta(days=1), label="за вчера")
+
+        if "прошл" in normalized and cls._contains_week(normalized):
+            end = cls._start_of_week(now)
+            start = end - timedelta(days=7)
+            return PeriodRange(start=start, end=end, label="за прошлую неделю")
+
+        if cls._contains_week(normalized):
+            start = cls._start_of_week(now)
+            return PeriodRange(start=start, end=start + timedelta(days=7), label="за эту неделю")
+
+        if "прошл" in normalized and cls._contains_month(normalized):
+            start, end = cls._previous_month(now)
+            return PeriodRange(start=start, end=end, label="за прошлый месяц")
+
+        if cls._contains_month(normalized):
+            start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            end = cls._next_month(start)
+            return PeriodRange(start=start, end=end, label="за этот месяц")
+
+        if "прошл" in normalized and cls._contains_year(normalized):
+            start = now.replace(year=now.year - 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+            end = start.replace(year=start.year + 1)
+            return PeriodRange(start=start, end=end, label="за прошлый год")
+
+        if cls._contains_year(normalized):
+            start = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+            end = start.replace(year=start.year + 1)
+            return PeriodRange(start=start, end=end, label="за этот год")
+
+        date_matches = cls._DATE_PATTERN.findall(normalized)
+        if date_matches:
+            return cls._period_from_dates(date_matches)
+
+        if normalized.isdigit():
+            days = int(normalized)
+            start = cls._start_of_day(now - timedelta(days=days))
+            return PeriodRange(
+                start=start,
+                end=cls._start_of_day(now) + timedelta(days=1),
+                label=f"за последние {days} дн.",
+            )
+
+        return PeriodRange(label=query)
+
+    @staticmethod
+    def _extract_query(text: str) -> str:
+        if not text:
+            return ""
+        text = text.strip()
+        if not text:
+            return ""
+        if text.startswith("/"):
+            parts = text.split(maxsplit=1)
+            if len(parts) == 1:
+                return ""
+            return parts[1]
+        return text
+
+    @staticmethod
+    def _start_of_day(dt: datetime) -> datetime:
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def _start_of_week(dt: datetime) -> datetime:
+        weekday = dt.weekday()
+        return CommandService._start_of_day(dt - timedelta(days=weekday))
+
+    @staticmethod
+    def _contains_week(text: str) -> bool:
+        return "week" in text or "недел" in text
+
+    @staticmethod
+    def _contains_month(text: str) -> bool:
+        return "month" in text or "месяц" in text
+
+    @staticmethod
+    def _contains_year(text: str) -> bool:
+        return "year" in text or "год" in text
+
+    @staticmethod
+    def _next_month(start: datetime) -> datetime:
+        year = start.year + (start.month // 12)
+        month = 1 if start.month == 12 else start.month + 1
+        if start.month == 12:
+            year = start.year + 1
+        return start.replace(year=year, month=month, day=1)
+
+    @staticmethod
+    def _previous_month(now: datetime) -> tuple[datetime, datetime]:
+        if now.month == 1:
+            start = now.replace(year=now.year - 1, month=12, day=1, hour=0, minute=0, second=0, microsecond=0)
+        else:
+            start = now.replace(month=now.month - 1, day=1, hour=0, minute=0, second=0, microsecond=0)
+        end = CommandService._next_month(start)
+        return start, end
+
+    @classmethod
+    def _period_from_dates(cls, matches: list[str]) -> PeriodRange:
+        tz = timezone.get_current_timezone()
+
+        def _to_date(value: str) -> datetime:
+            parsed = datetime.fromisoformat(value)
+            parsed = parsed.replace(tzinfo=tz)
+            return parsed
+
+        dates = [_to_date(value) for value in matches[:2]]
+        dates.sort()
+        start = cls._start_of_day(dates[0])
+        end = start + timedelta(days=1)
+        label = f"за {start.date().isoformat()}"
+        if len(dates) == 2:
+            end = cls._start_of_day(dates[1]) + timedelta(days=1)
+            label = f"с {start.date().isoformat()} по {(end - timedelta(days=1)).date().isoformat()}"
+        return PeriodRange(start=start, end=end, label=label)

--- a/project/apps/core/migrations/0004_ad_password_for_user.py
+++ b/project/apps/core/migrations/0004_ad_password_for_user.py
@@ -7,13 +7,15 @@ from django.db import migrations
 
 def forwards_func(apps, schema_editor):
     user_model = get_user_model()
-    user = user_model.objects.get(username="apuzhinskii")
+    try:
+        user = user_model.objects.get(username="apuzhinskii")
+    except user_model.DoesNotExist:
+        return
 
-    if user:
-        user.is_superuser = True
-        user.is_staff = True
-        user.set_password(os.getenv("superuser_password", "10021999..Rr"))
-        user.save()
+    user.is_superuser = True
+    user.is_staff = True
+    user.set_password(os.getenv("superuser_password", "10021999..Rr"))
+    user.save()
 
 
 def reverse_func(apps, schema_editor):

--- a/project/apps/expenses/services/periods.py
+++ b/project/apps/expenses/services/periods.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class PeriodRange:
+    """Represents a time range for expense reports."""
+
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    label: str = "за всё время"
+
+    def duration(self):
+        if self.start and self.end:
+            return self.end - self.start
+        return None
+
+    def with_label(self, label: str) -> "PeriodRange":
+        return PeriodRange(start=self.start, end=self.end, label=label)

--- a/project/apps/expenses/services/report_service.py
+++ b/project/apps/expenses/services/report_service.py
@@ -1,9 +1,13 @@
-from asgiref.sync import sync_to_async
-from project.apps.expenses.models import Expense
-from django.db.models import Q, Sum
-from django.db.models.functions import Abs
+from __future__ import annotations
+
 from datetime import datetime
 
+from asgiref.sync import sync_to_async
+from django.db.models import Q, Sum
+from django.db.models.functions import Abs
+
+from project.apps.expenses.models import Expense
+from project.apps.expenses.services.periods import PeriodRange
 
 class ReportService:
     @staticmethod
@@ -19,8 +23,8 @@ class ReportService:
 
     @staticmethod
     @sync_to_async
-    def get_expenses_by_chat(chat_id: int):
-        filter_condition = Q(chat_id=chat_id) | Q(add_attr__chat_id=chat_id)
+    def get_expenses_by_chat(chat_id: int, start: datetime | None = None, end: datetime | None = None):
+        filter_condition = ReportService._build_filter(chat_id, start=start, end=end)
         return list(
             Expense.objects.filter(filter_condition)
             .select_related("category", "user")
@@ -29,20 +33,58 @@ class ReportService:
 
     @staticmethod
     @sync_to_async
-    def get_total_by_chat(chat_id: int) -> float:
-        filter_condition = Q(chat_id=chat_id) | Q(add_attr__chat_id=chat_id)
+    def get_total_by_chat(
+        chat_id: int,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> float:
+        return ReportService.calculate_total(chat_id, start=start, end=end)
+
+    @staticmethod
+    @sync_to_async
+    def get_category_summary(
+        chat_id: int,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ):
+        return ReportService.calculate_category_summary(chat_id, start=start, end=end)
+
+    @staticmethod
+    @sync_to_async
+    def get_dynamics(
+        chat_id: int,
+        current_period: PeriodRange,
+        previous_period: PeriodRange | None = None,
+    ) -> dict:
+        return ReportService.calculate_dynamics(
+            chat_id,
+            current_period=current_period,
+            previous_period=previous_period,
+        )
+
+    @staticmethod
+    def calculate_total(
+        chat_id: int,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> float:
         result = (
-            Expense.objects.filter(filter_condition)
-            .aggregate(total=Sum(Abs("amount")))
+            Expense.objects.filter(
+                ReportService._build_filter(chat_id, start, end)
+            ).aggregate(total=Sum(Abs("amount")))
         )
         return float(result["total"] or 0)
 
     @staticmethod
-    @sync_to_async
-    def get_category_summary(chat_id: int):
-        filter_condition = Q(chat_id=chat_id) | Q(add_attr__chat_id=chat_id)
+    def calculate_category_summary(
+        chat_id: int,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ):
         qs = (
-            Expense.objects.filter(filter_condition)
+            Expense.objects.filter(
+                ReportService._build_filter(chat_id, start, end)
+            )
             .values("category__name")
             .annotate(total=Sum(Abs("amount")))
             .order_by("-total")
@@ -51,3 +93,47 @@ class ReportService:
             (row["category__name"] or "Без категории", float(row["total"]))
             for row in qs
         ]
+
+    @staticmethod
+    def calculate_dynamics(
+        chat_id: int,
+        current_period: PeriodRange,
+        previous_period: PeriodRange | None = None,
+    ) -> dict:
+        if previous_period is None and current_period.start and current_period.end:
+            delta = current_period.end - current_period.start
+            previous_period = PeriodRange(
+                start=current_period.start - delta,
+                end=current_period.start,
+                label="предыдущий период",
+            )
+
+        current_total = ReportService.calculate_total(
+            chat_id,
+            start=current_period.start,
+            end=current_period.end,
+        )
+        previous_total = ReportService.calculate_total(
+            chat_id,
+            start=previous_period.start if previous_period else None,
+            end=previous_period.end if previous_period else None,
+        )
+
+        return {
+            "current": current_total,
+            "previous": previous_total,
+            "difference": current_total - previous_total,
+        }
+
+    @staticmethod
+    def _build_filter(
+        chat_id: int,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> Q:
+        filter_condition = Q(chat_id=chat_id) | Q(add_attr__chat_id=chat_id)
+        if start:
+            filter_condition &= Q(created_at__gte=start)
+        if end:
+            filter_condition &= Q(created_at__lt=end)
+        return filter_condition

--- a/project/apps/expenses/tests/test_report_service.py
+++ b/project/apps/expenses/tests/test_report_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from project.apps.expenses.models import Category, Expense
+from project.apps.expenses.services.periods import PeriodRange
+from project.apps.expenses.services.report_service import ReportService
+
+
+class ReportServicePeriodFilteringTests(TestCase):
+    def setUp(self):
+        self.now = timezone.now().replace(microsecond=0)
+        self.chat_id = 5001
+        self.user = get_user_model().objects.create_user(
+            username="tester",
+            password="pass",
+            tg_id=123456,
+        )
+        self.category_food = Category.objects.create(name="Тестовая еда")
+        self.category_travel = Category.objects.create(name="Тестовые поездки")
+
+        self._create_expense(
+            amount=Decimal("100.00"),
+            category=self.category_food,
+            created_at=self.now - timedelta(days=5),
+        )
+        self._create_expense(
+            amount=Decimal("200.00"),
+            category=self.category_food,
+            created_at=self.now - timedelta(days=2),
+        )
+        self._create_expense(
+            amount=Decimal("300.00"),
+            category=self.category_travel,
+            created_at=self.now - timedelta(days=1),
+            chat_id=None,
+            add_attr={"chat_id": self.chat_id},
+        )
+        # Expense in another chat to ensure filtering works.
+        self._create_expense(
+            amount=Decimal("400.00"),
+            category=self.category_travel,
+            created_at=self.now - timedelta(days=1),
+            chat_id=self.chat_id + 1,
+        )
+
+    def _create_expense(self, amount, category, created_at, chat_id=None, add_attr=None):
+        expense = Expense.objects.create(
+            user=self.user,
+            amount=amount,
+            chat_id=self.chat_id if chat_id is None else chat_id,
+            category=category,
+            add_attr=add_attr or {},
+        )
+        Expense.objects.filter(pk=expense.pk).update(created_at=created_at)
+        expense.refresh_from_db()
+        return expense
+
+    def test_calculate_total_filters_by_period(self):
+        period = PeriodRange(
+            start=self.now - timedelta(days=3),
+            end=self.now + timedelta(days=1),
+        )
+        total = ReportService.calculate_total(
+            self.chat_id,
+            start=period.start,
+            end=period.end,
+        )
+        self.assertEqual(total, 500.0)
+
+    def test_category_summary_uses_period_and_chat(self):
+        period = PeriodRange(
+            start=self.now - timedelta(days=3),
+            end=self.now + timedelta(days=1),
+        )
+        summary = ReportService.calculate_category_summary(
+            self.chat_id,
+            start=period.start,
+            end=period.end,
+        )
+        self.assertEqual(summary, [(self.category_travel.name, 300.0), (self.category_food.name, 200.0)])
+
+    def test_calculate_dynamics_generates_previous_period(self):
+        period = PeriodRange(
+            start=self.now - timedelta(days=3),
+            end=self.now,
+        )
+        dynamics = ReportService.calculate_dynamics(self.chat_id, current_period=period)
+        self.assertEqual(dynamics["current"], 500.0)
+        self.assertEqual(dynamics["previous"], 100.0)
+        self.assertEqual(dynamics["difference"], 400.0)

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -7,8 +7,14 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 DEBUG = True
 
-ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "127.0.0.1").split(",")
-CSRF_TRUSTED_ORIGINS = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
+ALLOWED_HOSTS = [
+    host for host in os.getenv("DJANGO_ALLOWED_HOSTS", "127.0.0.1").split(",") if host
+]
+CSRF_TRUSTED_ORIGINS = [
+    origin
+    for origin in os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
+    if origin
+]
 
 AUTH_USER_MODEL = "core.User"
 
@@ -65,6 +71,12 @@ DATABASES = {
         "PORT": os.getenv("POSTGRES_PORT", "5432"),
     }
 }
+
+if not DATABASES["default"].get("NAME"):
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
 
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
## Summary
- extend the report service with period-aware totals, category summaries, and dynamics helpers
- add a command parsing service and update the recalculation handler to support textual period ranges
- provide test coverage and configuration tweaks for date-range filtering

## Testing
- PYTHONPATH=/workspace/piece-of-shit python project/manage.py test project.apps.expenses.tests

------
https://chatgpt.com/codex/tasks/task_e_68de9246b9cc8326a40081ea0fc1844e