### PR TITLE
Add inline command handling and tests

### DIFF
--- a/bot/core/handlers/expenses.py
+++ b/bot/core/handlers/expenses.py
@@ -1,5 +1,6 @@
 from aiogram import Router, types, Bot
 
+from bot.services.command_service import CommandService
 from project.apps.core.services.user_start_service import UserService
 from project.apps.expenses.services.expense_service import ExpenseService
 
@@ -8,6 +9,11 @@ expenses = Router()
 
 @expenses.message()
 async def save_expense(message: types.Message, bot: Bot):
+    command_service = CommandService(bot)
+    handled = await command_service.handle_message(message)
+    if handled:
+        return
+
     user, _ = await UserService.get_or_create_from_aiogram(message.from_user)
     expenses = await ExpenseService.create_from_message(user, message)
 

--- a/bot/core/handlers/inline.py
+++ b/bot/core/handlers/inline.py
@@ -1,0 +1,20 @@
+from aiogram import Bot, Router, types
+
+from bot.services.command_service import CommandService
+
+
+inline = Router()
+
+
+@inline.inline_query()
+async def inline_query_handler(query: types.InlineQuery, bot: Bot):
+    service = CommandService(bot)
+    results = await service.handle_inline_query(query)
+
+    await query.answer(results, is_personal=True, cache_time=0)
+
+
+@inline.chosen_inline_result()
+async def chosen_inline_result_handler(result: types.ChosenInlineResult, bot: Bot):
+    service = CommandService(bot)
+    await service.on_chosen_inline_result(result)

--- a/bot/core/setup.py
+++ b/bot/core/setup.py
@@ -1,9 +1,10 @@
 from aiogram import Dispatcher
 
 from bot.core.handlers.expenses import expenses
+from bot.core.handlers.inline import inline
 from bot.core.handlers.recalculate import admin_router
 from bot.core.handlers.start import start
 
 
 def setup_handlers(dp: Dispatcher):
-    dp.include_routers(start, admin_router, expenses)
+    dp.include_routers(start, admin_router, inline, expenses)

--- a/bot/services/command_service.py
+++ b/bot/services/command_service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import chain
+from typing import Iterable
+
+from aiogram import Bot, types
+from aiogram.types import InlineQueryResultArticle, InputTextMessageContent
+
+from .base_service import BaseService
+
+
+@dataclass(frozen=True, slots=True)
+class CommandDefinition:
+    """Description of a bot command that can be invoked without a slash."""
+
+    name: str
+    title: str
+    description: str
+    message_text: str
+    parse_mode: str | None = None
+    aliases: tuple[str, ...] = ()
+
+
+class CommandService(BaseService):
+    """Utility responsible for recognising and executing bot commands."""
+
+    COMMANDS: tuple[CommandDefinition, ...] = (
+        CommandDefinition(
+            name="help",
+            title="ℹ️ Помощь",
+            description="Подсказка по доступным действиям",
+            message_text=(
+                "ℹ️ Доступные команды:\n"
+                "• help — эта справка\n"
+                "• recalculate — пересчёт расходов в чате"
+            ),
+            aliases=("help", "/help", "помощь", "команды"),
+        ),
+    )
+
+    _alias_map: dict[str, CommandDefinition] = {}
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+
+        if not CommandService._alias_map:
+            alias_map: dict[str, CommandDefinition] = {}
+
+            for command in self.COMMANDS:
+                alias_candidates = set(command.aliases or ()) | {command.name}
+
+                for alias in alias_candidates:
+                    normalized = self._normalize_alias(alias)
+                    if normalized:
+                        alias_map[normalized] = command
+
+            CommandService._alias_map = alias_map
+
+        self._me_cache: types.User | None = None
+
+    @property
+    def default_command(self) -> CommandDefinition | None:
+        return self.COMMANDS[0] if self.COMMANDS else None
+
+    @staticmethod
+    def _normalize_alias(alias: str) -> str:
+        return alias.strip().lstrip("/").lower()
+
+    @staticmethod
+    def _normalize_token(token: str) -> str:
+        return token.strip().lstrip("/").lower()
+
+    @staticmethod
+    def _collect_entities(message: types.Message) -> Iterable[types.MessageEntity]:
+        return chain(message.entities or (), message.caption_entities or ())
+
+    async def _get_me(self) -> types.User | None:
+        if self._me_cache is None:
+            try:
+                self._me_cache = await self.bot.get_me()
+            except Exception:
+                self._me_cache = None
+        return self._me_cache
+
+    async def _strip_bot_mention(self, text: str) -> str:
+        if not text:
+            return ""
+
+        stripped = text.strip()
+        if not stripped.startswith("@"):
+            return stripped
+
+        me = await self._get_me()
+        if not me or not me.username:
+            return stripped
+
+        username = me.username.lower()
+
+        mention = f"@{username}"
+        if stripped.lower().startswith(mention):
+            return stripped[len(mention) :].strip()
+
+        return stripped
+
+    def _maybe_has_mention_entity(self, message: types.Message) -> bool:
+        for entity in self._collect_entities(message):
+            if entity.type in ("mention", "text_mention"):
+                return True
+        return False
+
+    async def _mentions_bot(self, message: types.Message) -> bool:
+        if not self._maybe_has_mention_entity(message):
+            return False
+
+        me = await self._get_me()
+        if not me:
+            return False
+
+        username = (me.username or "").lower()
+        text_sources = (message.text or "", message.caption or "")
+
+        for entity in self._collect_entities(message):
+            if entity.type == "text_mention" and entity.user and entity.user.id == me.id:
+                return True
+
+            if entity.type == "mention" and username:
+                for source in text_sources:
+                    if not source:
+                        continue
+                    start = entity.offset
+                    end = entity.offset + entity.length
+                    mention_text = source[start:end]
+                    if mention_text.lower() == f"@{username}":
+                        return True
+
+        return False
+
+    def get_command_from_text(self, text: str) -> CommandDefinition | None:
+        if not text:
+            return None
+
+        stripped = text.strip()
+        if not stripped:
+            return None
+
+        token = stripped.split()[0]
+        normalized = self._normalize_token(token)
+        if not normalized:
+            return None
+
+        return self._alias_map.get(normalized)
+
+    async def get_command_from_message(self, message: types.Message) -> CommandDefinition | None:
+        text = message.text or message.caption or ""
+        text = await self._strip_bot_mention(text)
+        return self.get_command_from_text(text)
+
+    async def handle_message(self, message: types.Message) -> bool:
+        command = await self.get_command_from_message(message)
+        mentions_bot = await self._mentions_bot(message)
+
+        if not command and not mentions_bot:
+            return False
+
+        command_to_execute = command or self.default_command
+        if not command_to_execute:
+            return False
+
+        await message.answer(
+            command_to_execute.message_text,
+            parse_mode=command_to_execute.parse_mode,
+        )
+
+        return True
+
+    def build_inline_article(self, command: CommandDefinition) -> InlineQueryResultArticle:
+        return InlineQueryResultArticle(
+            id=command.name,
+            title=command.title,
+            description=command.description,
+            input_message_content=InputTextMessageContent(
+                message_text=command.message_text,
+                parse_mode=command.parse_mode,
+            ),
+        )
+
+    async def handle_inline_query(self, inline_query: types.InlineQuery) -> list[InlineQueryResultArticle]:
+        command = self.get_command_from_text(inline_query.query or "")
+        if not command:
+            return []
+
+        return [self.build_inline_article(command)]
+
+    async def on_chosen_inline_result(self, result: types.ChosenInlineResult) -> None:
+        # For now we only keep the hook for future extensions (logging, metrics, etc.)
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ python-decouple = "^3.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
+pytest-asyncio = "^0.24.0"
 flake8 = "^7.1.1"
 watchfiles = "^1.1.0"
 

--- a/tests/bot/test_command_flow.py
+++ b/tests/bot/test_command_flow.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiogram import types
+
+from bot.core.handlers.expenses import save_expense
+from bot.core.handlers.inline import inline_query_handler
+from bot.services.command_service import CommandService
+from project.apps.core.services import user_start_service
+from project.apps.expenses.services import expense_service
+
+
+@pytest.mark.asyncio
+async def test_inline_query_returns_article_for_known_command(monkeypatch):
+    bot = AsyncMock()
+    query = MagicMock(spec=types.InlineQuery)
+    query.query = "help"
+    query.answer = AsyncMock()
+
+    await inline_query_handler(query, bot)
+
+    query.answer.assert_awaited()
+    answered_results = query.answer.await_args.args[0]
+    assert len(answered_results) == 1
+
+    result = answered_results[0]
+    assert result.title == CommandService.COMMANDS[0].title
+    assert result.input_message_content.message_text == CommandService.COMMANDS[0].message_text
+
+
+@pytest.mark.asyncio
+async def test_expense_handler_delegates_to_command_service_on_mention(monkeypatch):
+    bot = AsyncMock()
+    bot.get_me = AsyncMock(
+        return_value=types.User(id=999, is_bot=True, first_name="Inline", username="test_bot")
+    )
+
+    message = MagicMock(spec=types.Message)
+    message.text = "@test_bot help"
+    message.caption = None
+    message.entities = [types.MessageEntity(type="mention", offset=0, length=9)]
+    message.caption_entities = None
+    message.answer = AsyncMock()
+    message.from_user = types.User(id=1, is_bot=False, first_name="User")
+
+    user_service_mock = AsyncMock()
+    expense_service_mock = AsyncMock()
+    monkeypatch.setattr(user_start_service.UserService, "get_or_create_from_aiogram", user_service_mock)
+    monkeypatch.setattr(expense_service.ExpenseService, "create_from_message", expense_service_mock)
+
+    await save_expense(message, bot)
+
+    message.answer.assert_awaited()
+    user_service_mock.assert_not_awaited()
+    expense_service_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_expense_handler_processes_regular_expense(monkeypatch):
+    bot = AsyncMock()
+    bot.get_me = AsyncMock()
+
+    message = MagicMock(spec=types.Message)
+    message.text = "100 кофе"
+    message.caption = None
+    message.entities = []
+    message.caption_entities = None
+    message.answer = AsyncMock()
+    message.from_user = types.User(id=2, is_bot=False, first_name="User2")
+    message.chat = types.Chat(id=123, type="private")
+    message.message_id = 10
+    message.date = None
+
+    fake_user = SimpleNamespace(id=1)
+    user_service_mock = AsyncMock(return_value=(fake_user, False))
+    fake_expense = SimpleNamespace(category=SimpleNamespace(name="Кофе"), amount=100)
+    expense_service_mock = AsyncMock(return_value=[fake_expense])
+
+    monkeypatch.setattr(user_start_service.UserService, "get_or_create_from_aiogram", user_service_mock)
+    monkeypatch.setattr(expense_service.ExpenseService, "create_from_message", expense_service_mock)
+
+    await save_expense(message, bot)
+
+    user_service_mock.assert_awaited_once()
+    expense_service_mock.assert_awaited_once()
+    bot.get_me.assert_not_awaited()
+    message.answer.assert_not_awaited()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from pathlib import Path
+
+import django
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.config.settings")
+django.setup()


### PR DESCRIPTION
## Summary
- add a command service that recognises text commands, builds inline responses, and replies to messages mentioning the bot
- register an inline router alongside expenses handling to expose the new command flow
- cover inline query, mention interception, and regular expense scenarios with async pytest tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9243113c8326b2ff86b0d5f45f9f