### PR TITLE
Fix aiogram command handler registration

### DIFF
--- a/bot/core/handlers/commands.py
+++ b/bot/core/handlers/commands.py
@@ -1,5 +1,4 @@
-from aiogram import Bot, Router, types
-from aiogram.filters import Command
+from aiogram import Bot, F, Router, types
 
 from project.apps.core.services.command_service import CommandService
 from project.apps.core.services.user_start_service import UserService
@@ -7,7 +6,7 @@ from project.apps.core.services.user_start_service import UserService
 commands = Router()
 
 
-@commands.message(Command())
+@commands.message(F.text.startswith("/"))
 async def handle_command(message: types.Message, bot: Bot):
     user, _ = await UserService.get_or_create_from_aiogram(message.from_user)
 


### PR DESCRIPTION
## Summary
- replace the empty aiogram Command filter with a simple text check so dynamic commands can be processed without errors

## Testing
- ⚠️ `poetry run pytest` *(fails to run because Poetry requires Python 3.13 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec18e84e883268487079853895eb3