### PR TITLE
Fix aiogram command handler registration

### DIFF
--- a/bot/core/handlers/commands.py
+++ b/bot/core/handlers/commands.py
@@ -1,5 +1,4 @@
-from aiogram import Bot, Router, types
-from aiogram.filters import Command
+from aiogram import Bot, F, Router, types
 
 from project.apps.core.services.command_service import CommandService
 from project.apps.core.services.user_start_service import UserService
@@ -7,7 +6,7 @@ from project.apps.core.services.user_start_service import UserService
 commands = Router()
 
 
-@commands.message(Command())
+@commands.message(F.text.startswith("/"))
 async def handle_command(message: types.Message, bot: Bot):
     user, _ = await UserService.get_or_create_from_aiogram(message.from_user)
 

--- a/bot/core/handlers/expenses.py
+++ b/bot/core/handlers/expenses.py
@@ -1,5 +1,6 @@
 from aiogram import Bot, Router, types
 
+from bot.services.command_service import CommandService as BotCommandService
 from project.apps.core.services.command_service import CommandService
 from project.apps.core.services.user_start_service import UserService
 from project.apps.expenses.services.expense_service import ExpenseService
@@ -9,8 +10,8 @@ expenses = Router()
 
 @expenses.message()
 async def save_expense(message: types.Message, bot: Bot):
-    command_service = CommandService(bot)
-    handled = await command_service.handle_message(message)
+    bot_command_service = BotCommandService(bot)
+    handled = await bot_command_service.handle_message(message)
     if handled:
         return
 


### PR DESCRIPTION
## Summary
- replace the empty aiogram Command filter with a simple text check so dynamic commands can be processed without errors
- update the expense handler to instantiate the bot-level command service when checking default bot commands so runtime errors no longer occur

## Testing
- ❌ `poetry run pytest` *(fails: repository lacks async pytest plugin, database tables such as `core_user`, and legacy tests still expect `CommandService.parse_period()` to exist)*

------
https://chatgpt.com/codex/tasks/task_e_68dec18e84e883268487079853895eb3